### PR TITLE
update README.MD

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -38,7 +38,7 @@
 2. 安装gitbook。
 
    ```shell
-   npm i -g gitbook gitbook-cli
+   npm i -g gitbook-cli
    ```
 
 3. 本地进入到本项目根目录，运行：


### PR DESCRIPTION
You need to install "gitbook-cli" to have access to the gitbook command anywhere on your system.
If you've installed this package globally, you need to uninstall it.
>> Run "npm uninstall -g gitbook" then "npm install -g gitbook-cli"