### PR TITLE
fix: failed to load prism syntax: shell

### DIFF
--- a/book.json
+++ b/book.json
@@ -27,6 +27,11 @@
     "-highlight"
   ],
   "pluginsConfig": {
+    "prism": {
+      "lang": {
+        "shell": "bash"
+      }
+    },
     "search-pro": {
       "cutWordLib": "nodejieba",
       "defineWord" : ["Gitbook Use"]


### PR DESCRIPTION
本地执行`gitbook serve`时，控制台报错，信息如下：
```bash
Failed to load prism syntax: shell
{ Error: Cannot find module 'prismjs/components/prism-shell.js'
    at Function.Module._resolveFilename (module.js:538:15)
    at Function.Module._load (module.js:468:25)
    at Module.require (module.js:587:17)
    at require (internal/module.js:11:18)
    at requireSyntax (/Users/look/study/flutter/flutter-in-action/node_modules/gitbook-plugin-prism/index.js:31:3)
    at Object.code (/Users/look/study/flutter/flutter-in-action/node_modules/gitbook-plugin-prism/index.js:103:11)
    at Record.TemplateBlock.applyBlock (/Users/look/.gitbook/versions/3.2.3/lib/models/templateBlock.js:205:23)
    at /Users/look/.gitbook/versions/3.2.3/lib/output/getModifiers.js:56:33
    at /Users/look/.gitbook/versions/3.2.3/lib/output/modifiers/highlightCode.js:47:24
    at /Users/look/.gitbook/versions/3.2.3/lib/output/modifiers/editHTMLElement.js:11:16 code: 'MODULE_NOT_FOUND' }
```
根据报错信息，查看`/flutter-in-action/node_modules/gitbook-plugin-prism/index.js`文件及[gitbook-plugin-prism插件配置][1]可以知道，插件默认不支持以`shell`语法前缀作为`bash`语法前缀的别名，所以会报错，但是支持自定义，添加上以下配置即可：
```json
"pluginsConfig": {
    "prism": {
      "lang": {
        "shell": "bash"
      }
    }
}
```

[1]: https://github.com/gaearon/gitbook-plugin-prism#lang