### PR TITLE
Update flutter_widget_intro.md

### DIFF
--- a/docs/chapter3/flutter_widget_intro.md
+++ b/docs/chapter3/flutter_widget_intro.md
@@ -380,7 +380,7 @@ class _TapboxAState extends State<TapboxA> {
 
 对于父widget来说，管理状态并告诉其子widget何时更新通常是比较好的方式。 例如，IconButton是一个图片按钮，但它是一个无状态的widget，因为我们认为父widget需要知道该按钮是否被点击来采取相应的处理。
 
-在以下示例中，TapboxB通过回调将其状态导出到其父项。由于TapboxB不管理任何状态，因此它的父类为StatelessWidget。
+在以下示例中，TapboxB通过回调将其状态导出到其父项。由于TapboxB不管理任何状态，因此它的父类为StatefulWidget, TapboxB为StatelessWidget。
 
 ParentWidgetState 类:
 


### PR DESCRIPTION
父widget管理子widget状态章节, “由于TapboxB不管理任何状态，因此它的父类为StatelessWidget”, 此处可能为作者笔误, 应该是父类为StatefulWidget