### PR TITLE
initState方法也被注释为@mustCallSuper

### DIFF
--- a/docs/chapter6/listview.md
+++ b/docs/chapter6/listview.md
@@ -134,6 +134,7 @@ class _InfiniteListViewState extends State<InfiniteListView> {
 
   @override
   void initState() {
+    super.initState();
     _retrieveData();
   }
 


### PR DESCRIPTION
This method overrides a method annotated as @mustCallSuper in 'State', but does not invoke the overridden method.