### PR TITLE
Update gradient_circular_progress_demo.md

### DIFF
--- a/docs/chapter13/gradient_circular_progress_demo.md
+++ b/docs/chapter13/gradient_circular_progress_demo.md
@@ -86,8 +86,8 @@ class GradientCircularProgressIndicator extends StatelessWidget {
 //实现画笔
 class _GradientCircularProgressPainter extends CustomPainter {
   _GradientCircularProgressPainter({
-    this.stokeWidth: 10.0,
-    this.strokeCapRound: false,
+    this.stokeWidth = 10.0,
+    this.strokeCapRound = false,
     this.backgroundColor = const Color(0xFFEEEEEE),
     this.radius,
     this.total = 2 * pi,


### PR DESCRIPTION
使用 `:` 作为构造函数参数的默认值做法已经不赞成使用了。
[Default parameter values](https://dart.dev/guides/language/language-tour#default-value)