### PR TITLE
Add super.initState() for @mustCallSuper

### DIFF
--- a/docs/chapter6/scroll_controller.md
+++ b/docs/chapter6/scroll_controller.md
@@ -49,6 +49,7 @@ class ScrollControllerTestRouteState extends State<ScrollControllerTestRoute> {
 
   @override
   void initState() {
+    super.initState();
     //监听滚动事件，打印滚动位置
     _controller.addListener(() {
       print(_controller.offset); //打印滚动位置


### PR DESCRIPTION
 ScrollControllerTestRouteState 继承了 State，initState方法必须调用super.initState()。如下代码所示：

`
/// If you override this, make sure your method starts with a call to
  /// super.initState().
  @protected
  @mustCallSuper
  void initState() {
    assert(_debugLifecycleState == _StateLifecycle.created);
  }
`