### PR TITLE
2.1 计数器示例错别字修改‘嗾使-->都是'

### DIFF
--- a/docs/chapter2/first_flutter_app.md
+++ b/docs/chapter2/first_flutter_app.md
@@ -231,7 +231,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
 #### 为什么要将build方法放在State中，而不是放在StatefulWidget中？
 
-现在，我们回答之前提出的问题，为什么`build()`方法房在State（而不是`StatefulWidget`）中 ？这主要是为了提高开发的灵活性。如果将`build()`方法在`StatefulWidget`中则会有两个问题：
+现在，我们回答之前提出的问题，为什么`build()`方法放在State（而不是`StatefulWidget`）中 ？这主要是为了提高开发的灵活性。如果将`build()`方法在`StatefulWidget`中则会有两个问题：
 
 - 状态访问不便
 

--- a/docs/chapter2/first_flutter_app.md
+++ b/docs/chapter2/first_flutter_app.md
@@ -128,7 +128,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
    - `MyApp`类代表Flutter应用，它继承了 `StatelessWidget `类，这也就意味着应用本身也是一个widget。
 
-   - 在Flutter中，大多数东西都是widget（后同”组件“或”部件“），包括对齐(alignment)、填充(padding)和布局(layout)等，它们嗾使以widget的形式提供。
+   - 在Flutter中，大多数东西都是widget（后同”组件“或”部件“），包括对齐(alignment)、填充(padding)和布局(layout)等，它们都是以widget的形式提供。
 
    - Flutter在构建页面时，会调用组件的`build`方法，widget的主要工作是提供一个build()方法来描述如何构建UI界面（通常是通过组合、拼装其它基础widget）。
 


### PR DESCRIPTION
它们嗾使以widget的形式提供。

改为

它们都是以widget的形式提供。