### PR TITLE
Update theme.md

### DIFF
--- a/docs/chapter7/theme.md
+++ b/docs/chapter7/theme.md
@@ -174,6 +174,10 @@ class _ThemeTestRouteState extends State<ThemeTestRoute> {
       data: ThemeData(
           primarySwatch: _themeColor, //用于导航栏、FloatingActionButton的背景色等
           iconTheme: IconThemeData(color: _themeColor) //用于Icon颜色
+          textTheme: TextTheme(
+              body1: TextStyle(
+            color: _themeColor,
+          ))),
       ),
       child: Scaffold(
         appBar: AppBar(title: Text("主题测试")),


### PR DESCRIPTION
例子中未设置textTheme导致在更换主题的时候未能更换文字的颜色。已在iconTheme下面添加了对应的代码。