### PR TITLE
“运行效果如图 3-26 所示” 上面的 “设置 controller” 处文本排版错误。

### DIFF
--- a/docs/chapter3/input_and_form.md
+++ b/docs/chapter3/input_and_form.md
@@ -192,7 +192,7 @@ _selectionController.selection=TextSelection(
 );
 ```
 
-设置`controlle`r:
+设置`controller`:
 
 ```dart
 TextField(


### PR DESCRIPTION
# 3.7 输入框及表单 排版错误

> `controller` 写成了 `contolle`r

![image](https://user-images.githubusercontent.com/56432636/89104355-6fb52680-d44b-11ea-8b36-18fd5ce1ca26.png)
