### PR TITLE
fix: 勘误

### DIFF
--- a/docs/chapter1/flutter_intro.md
+++ b/docs/chapter1/flutter_intro.md
@@ -101,7 +101,7 @@ Flutter框架本身有着良好的分层设计，本节旨在让读者对Flutter
 ### 社区
 
 - **StackOverflow**：如果你还没听过StackOverflow，这是目前全球最大的程序员问答社区，现在也是活跃度最高的Flutter问答社区。StackOverflow上面除了世界各地的Flutter使用者会在上面交流之外，Flutter开发团队的成员也经常会在上面回答问题。
-- **Flutter中文网社区**：Flutter中文网(https://flutterchina.club)是笔者维护中文网站，目前也是最大的中文资源社区，上面提供了Flutter官网的文档翻译、开源项目、及案例，还有申请加入组织的入口哦。
+- **Flutter中文网社区**：Flutter中文网([https://flutterchina.club](https://flutterchina.club))是笔者维护中文网站，目前也是最大的中文资源社区，上面提供了Flutter官网的文档翻译、开源项目、及案例，还有申请加入组织的入口哦。
 - **博客**：随着Flutter技术的推广，相信很快网上将会有很多Flutter相关的文章、博客，读者可以多去浏览、阅读。
 
 ### 总结


### PR DESCRIPTION
github渲染时将链接地址和后面的文字粘在了一次，导致链接错误

eg.
https://github.com/flutterchina/flutter-in-action/blob/master/docs/chapter1/flutter_intro.md#%E7%A4%BE%E5%8C%BA