### PR TITLE
fix deprecated class

### DIFF
--- a/src/chapter2/flutter_router.md
+++ b/src/chapter2/flutter_router.md
@@ -33,7 +33,7 @@
          mainAxisAlignment: MainAxisAlignment.center,
          children: <Widget>[
          ... //省略无关代码
-         FlatButton(
+         TextButton(
             child: Text("open new route"),
             textColor: Colors.blue,
             onPressed: () {


### PR DESCRIPTION
Flatbutton class is deprecated after v1.25.0-8.1.pre, per flutter
official doc <https://api.flutter.dev/flutter/material/FlatButton-class.html>
